### PR TITLE
アクセシビリティ周りの修正

### DIFF
--- a/src/components/IframeItem/index.tsx
+++ b/src/components/IframeItem/index.tsx
@@ -3,12 +3,22 @@ import style from './style.module.css';
 type Props = {
   url: string;
   memo: string;
+  current: number;
+  total: number;
+  hidden: boolean; // 表示されてないitemは支援技術に伝えたくないしタブ移動させたくないのでその判別に使う
 };
 
-function IframeItem({ url, memo }: Props) {
+function IframeItem({ url, memo, current, total, hidden }: Props) {
   return (
-    <article className={style.IframeItem}>
+    <article
+      className={style.IframeItem}
+      role="group"
+      aria-roledescription="slide"
+      aria-label={`${total}枚中の${current}枚目`}
+      aria-hidden={hidden}
+    >
       <iframe
+        tabIndex={hidden ? -1 : 0}
         width="100%"
         height="315"
         src={url}

--- a/src/components/IframeList/index.tsx
+++ b/src/components/IframeList/index.tsx
@@ -17,14 +17,31 @@ function IframeList({ list, defaultIndex }: Props) {
       listSize: list.length,
     });
   return (
-    <section className={style.IframeList}>
-      <p>index: {selectedIndex}</p>
+    <section
+      className={style.IframeList}
+      aria-roledescription="carousel"
+      aria-label="マーカッポ動画一覧"
+    >
+      <p>
+        {list.length}枚中の{selectedIndex + 1}枚目
+      </p>
       <div className={style.IframeList__main}>
         {!isFirst && <PrevButton onClick={toPrev} />}
         {!isLast && <NextButton onClick={toNext} />}
-        <div ref={containerRef} className={style.IframeList__container}>
+        <div
+          ref={containerRef}
+          className={style.IframeList__container}
+          aria-live="polite" // 動画が切り替わった時に支援技術に伝える
+        >
           {list.map(({ url, memo }, index) => (
-            <IframeItem key={index} url={url} memo={memo} />
+            <IframeItem
+              key={index}
+              url={url}
+              memo={memo}
+              current={index + 1}
+              total={list.length}
+              hidden={selectedIndex !== index}
+            />
           ))}
         </div>
       </div>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -29,14 +29,18 @@ export default function Home() {
         <h1>Next Swipe Iframe Sample</h1>
         <p>iframeをスワイプして次のiframeに表示を切り換えるサンプル</p>
         <p>以下のページを参考にした</p>
-        <p>
-          <a href="https://react-spectrum.adobe.com/react-aria/examples/swipeable-tabs.html">
-            https://react-spectrum.adobe.com/react-aria/examples/swipeable-tabs.html
-          </a>
-        </p>
-        <p>ああああ</p>
-        <p>ああああ</p>
-        <p>ああああ</p>
+        <ul>
+          <li>
+            <a href="https://react-spectrum.adobe.com/react-aria/examples/swipeable-tabs.html">
+              https://react-spectrum.adobe.com/react-aria/examples/swipeable-tabs.html
+            </a>
+          </li>
+          <li>
+            <a href="https://www.w3.org/WAI/ARIA/apg/patterns/carousel/examples/carousel-1-prev-next/">
+              https://www.w3.org/WAI/ARIA/apg/patterns/carousel/examples/carousel-1-prev-next/
+            </a>
+          </li>
+        </ul>
         <IframeList list={list} defaultIndex={1} />
       </main>
     </>


### PR DESCRIPTION
## 概要

- 適切なaria属性の付与など
- 以下のページを参考に対応
    - https://www.w3.org/WAI/ARIA/apg/patterns/carousel/examples/carousel-1-prev-next/

## 修正内容

- ariaやroleの付与
- 選択されてない動画をタブ移動できなくしてアクセシビリティツリーからも見えないようにした
- 動画が切り替わった時に支援技術に伝わるようにした