### PR TITLE
キー操作でスライドが切り替わるように修正

### DIFF
--- a/src/hooks/useSwiper.ts
+++ b/src/hooks/useSwiper.ts
@@ -106,6 +106,9 @@ function useSwiper({ listSize, index }: Props) {
     }
   }, [index, listSize]);
 
+  /**
+   * このhooksを呼んでいるコンポーネンを表示してる間はキーボードの左右キーでスライドを切り替えられるようにする
+   */
   useEffect(() => {
     const onKeydown = (e: KeyboardEvent) => {
       if (e.key === 'ArrowLeft') {

--- a/src/hooks/useSwiper.ts
+++ b/src/hooks/useSwiper.ts
@@ -42,7 +42,6 @@ function useSwiper({ listSize, index }: Props) {
     (nextIndex: number) => {
       const container = containerRef.current;
       if (!container) return;
-
       animationRef.current?.stop();
       animationRef.current = animate(
         container.scrollLeft,
@@ -70,7 +69,9 @@ function useSwiper({ listSize, index }: Props) {
    * 前のindexにスクロールさせる
    */
   const toPrev = useCallback(() => {
+    console.log('toPrev');
     if (isFirst) return;
+    console.log({ selectedIndex });
     setSelectedIndex(selectedIndex - 1);
     scrollTo(selectedIndex - 1);
   }, [selectedIndex, isFirst, scrollTo]);
@@ -79,7 +80,9 @@ function useSwiper({ listSize, index }: Props) {
    * 次のindexにスクロールさせる
    */
   const toNext = useCallback(() => {
+    console.log('toNext');
     if (isLast) return;
+    console.log({ selectedIndex });
     setSelectedIndex(selectedIndex + 1);
     scrollTo(selectedIndex + 1);
   }, [selectedIndex, isLast, scrollTo]);
@@ -102,6 +105,18 @@ function useSwiper({ listSize, index }: Props) {
       container.scrollLeft = container.scrollWidth * (index / listSize);
     }
   }, [index, listSize]);
+
+  useEffect(() => {
+    const onKeydown = (e: KeyboardEvent) => {
+      if (e.key === 'ArrowLeft') {
+        toPrev();
+      } else if (e.key === 'ArrowRight') {
+        toNext();
+      }
+    };
+    window.addEventListener('keydown', onKeydown);
+    return () => window.removeEventListener('keydown', onKeydown);
+  }, [toPrev, toNext]);
 
   return {
     toPrev,

--- a/src/hooks/useSwiper.ts
+++ b/src/hooks/useSwiper.ts
@@ -69,9 +69,7 @@ function useSwiper({ listSize, index }: Props) {
    * 前のindexにスクロールさせる
    */
   const toPrev = useCallback(() => {
-    console.log('toPrev');
     if (isFirst) return;
-    console.log({ selectedIndex });
     setSelectedIndex(selectedIndex - 1);
     scrollTo(selectedIndex - 1);
   }, [selectedIndex, isFirst, scrollTo]);
@@ -80,9 +78,7 @@ function useSwiper({ listSize, index }: Props) {
    * 次のindexにスクロールさせる
    */
   const toNext = useCallback(() => {
-    console.log('toNext');
     if (isLast) return;
-    console.log({ selectedIndex });
     setSelectedIndex(selectedIndex + 1);
     scrollTo(selectedIndex + 1);
   }, [selectedIndex, isLast, scrollTo]);

--- a/src/hooks/useSwiper.ts
+++ b/src/hooks/useSwiper.ts
@@ -103,7 +103,7 @@ function useSwiper({ listSize, index }: Props) {
   }, [index, listSize]);
 
   /**
-   * このhooksを呼んでいるコンポーネンを表示してる間はキーボードの左右キーでスライドを切り替えられるようにする
+   * このhooksを呼んでいるコンポーネントを表示してる間はキーボードの左右キーでスライドを切り替えられるようにする
    */
   useEffect(() => {
     const onKeydown = (e: KeyboardEvent) => {


### PR DESCRIPTION
## 概要

- キーボードの左右キーでスライドが切り替わるようにした
- hooksを呼んでいるコンポーネントを表示してる間はキー操作が有効になる
- なので現状画面上の他の要素とキー操作が競合する場合は対応できていない